### PR TITLE
방 목록 조회 API 리팩토링 및 swagger 문서화 추가

### DIFF
--- a/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/converter/RoomConverter.java
+++ b/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/converter/RoomConverter.java
@@ -3,8 +3,11 @@ package com.notFoundTomAndJerry.notFoundJerry.domain.room.converter;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.JoinRoomResponse;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.ParticipantDetailResponse;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.RoomDetailResponse;
+import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.RoomListResponse;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.entity.Room;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.entity.RoomParticipant;
+import com.notFoundTomAndJerry.notFoundJerry.global.exception.BusinessException;
+import com.notFoundTomAndJerry.notFoundJerry.global.exception.domain.RoomErrorCode;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
@@ -14,6 +17,23 @@ import java.util.stream.Collectors;
 
 @Component
 public class RoomConverter {
+
+    /**
+     * 방 목록 조회 DTO (닉네임 없음)
+     */
+    public RoomListResponse toListResponse(Room room) {
+        if (room == null) return null;
+
+        return RoomListResponse.builder()
+                .roomId(room.getId())
+                .locationId(room.getLocationId())
+                .title(room.getTitle())
+                .status(room.getStatus())
+                .maxPlayers(room.getMaxPlayers())
+                .currentParticipants(room.getCurrentParticipantCount())
+                .startTime(room.getStartTime())
+                .build();
+    }
 
     /**
      * 방 상세 정보 DTO 변환 (닉네임 포함)
@@ -62,7 +82,7 @@ public class RoomConverter {
         RoomParticipant participant = room.getParticipants().stream()
                 .filter(p -> p.getUserId().equals(userId))
                 .findFirst()
-                .orElseThrow(() -> new IllegalStateException("참가자 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new BusinessException(RoomErrorCode.PARTICIPANT_NOT_FOUND));
 
         return JoinRoomResponse.builder()
                 .roomId(room.getId())

--- a/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/dto/request/RoomListRequest.java
+++ b/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/dto/request/RoomListRequest.java
@@ -1,12 +1,26 @@
 package com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.request;
 
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.entity.enums.RoomStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
+@Schema(description = "방 목록 조회 요청")
 public class RoomListRequest {
+    @Schema(
+            description = "지역 ID (선택사항)",
+            example = "1",
+            nullable = true
+    )
     private Long locationId;
+    @Schema(
+            description = "방 상태 (선택사항)",
+            example = "WAITING",
+            nullable = true
+    )
     private RoomStatus status;
 }

--- a/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/dto/response/RoomListResponse.java
+++ b/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/dto/response/RoomListResponse.java
@@ -1,0 +1,19 @@
+package com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response;
+
+import com.notFoundTomAndJerry.notFoundJerry.domain.room.entity.enums.RoomStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class RoomListResponse {
+    private Long roomId;
+    private Long locationId;
+    private String title;
+    private RoomStatus status;
+    private Integer maxPlayers;
+    private Integer currentParticipants;
+    private LocalDateTime startTime;
+}

--- a/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/service/RoomService.java
+++ b/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/service/RoomService.java
@@ -4,6 +4,7 @@ import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.request.CreateRoomR
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.request.RoomListRequest;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.JoinRoomResponse;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.RoomDetailResponse;
+import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.RoomListResponse;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.entity.enums.ParticipantRole;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,7 +19,7 @@ public interface RoomService {
     /**
      * 방 목록 조회 (필터 + 페이징)
      */
-    Page<RoomDetailResponse> listRooms(RoomListRequest request, Pageable pageable);
+    Page<RoomListResponse> listRooms(RoomListRequest request, Pageable pageable);
 
     /**
      * 방 단건 조회 (상세)


### PR DESCRIPTION

## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호
#65 
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- RoomListResponse DTO 작성
- RoomConverter에 간단한 방 목록 변환 메서드(toListResponse) 추가
- RoomService 및 RoomServiceImpl의 목록 조회 응답 타입 수정
- RoomController에 방 목록 조회 API 구현 (Swagger 문서화 포함)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요