### PR TITLE
지도 마커 조회 API 및 위치별 방 개수 집계 로직 추가

### DIFF
--- a/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/location/controller/LocationController.java
+++ b/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/location/controller/LocationController.java
@@ -5,11 +5,13 @@ import com.notFoundTomAndJerry.notFoundJerry.domain.location.service.LocationSer
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@CrossOrigin(origins = "http://localhost:5173")
 @RestController
 @RequestMapping("/api/locations")
 @RequiredArgsConstructor

--- a/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/location/entity/Location.java
+++ b/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/location/entity/Location.java
@@ -31,6 +31,12 @@ public class Location {
   @Column(columnDefinition = "POINT SRID 4326", nullable = false)
   private Point point; // 위경도 공간 데이터
 
+  @Column(nullable = false)
+  private Double latitude;
+
+  @Column(nullable = false)
+  private Double longitude;
+
   @Column(nullable = true)
   private String address; // 전체 주소
 
@@ -59,6 +65,11 @@ public class Location {
   // 공공데이터 API로부터 받은 공원 정보 업데이트
   public void updateFromPublicApi(String manageNo, String parkNm, String parkSe, String parkAr,
       String lat, String lon) {
+
+    // 위경도 숫자 변환
+    this.latitude = Double.parseDouble(lat);
+    this.longitude = Double.parseDouble(lon);
+
     // 위경도 -> Point 변환
     GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
     double longitude = Double.parseDouble(lon);

--- a/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/controller/RoomController.java
+++ b/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/controller/RoomController.java
@@ -4,6 +4,7 @@ import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.request.ChangeRoleR
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.request.CreateRoomRequest;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.request.RoomListRequest;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.JoinRoomResponse;
+import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.LocationWithRoomCountResponse;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.RoomDetailResponse;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.RoomListResponse;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.service.RoomService;
@@ -11,6 +12,7 @@ import com.notFoundTomAndJerry.notFoundJerry.global.security.CustomPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
@@ -108,6 +110,19 @@ public class RoomController {
     ) {
         roomService.changeRole(roomId, targetUserId, request.getRole());
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 지도 마커 조회 API 현재 지도 영역(Bounding Box) 내의 장소별 대기/게임 중인 방 개수를 반환
+     */
+    @GetMapping("/map-markers")
+    public List<LocationWithRoomCountResponse> getMapMarkers(
+        @RequestParam(name = "minLat", required = false, defaultValue = "30.0") Double minLat,
+        @RequestParam(name = "maxLat", required = false, defaultValue = "45.0") Double maxLat,
+        @RequestParam(name = "minLng", required = false, defaultValue = "120.0") Double minLng,
+        @RequestParam(name = "maxLng", required = false, defaultValue = "135.0") Double maxLng
+    ) {
+        return roomService.getMapMarkers(minLat, maxLat, minLng, maxLng);
     }
 
 }

--- a/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/dto/response/LocationWithRoomCountResponse.java
+++ b/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/dto/response/LocationWithRoomCountResponse.java
@@ -1,0 +1,19 @@
+package com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class LocationWithRoomCountResponse {
+
+  private Long locationId;      // 장소 고유 ID
+  private String parkNm;        // 공원 이름
+  private Double latitude;      // 위도
+  private Double longitude;     // 경도
+  private String address;       // 주소
+  private Long waitingRoomCount; // 해당 장소의 WAITING 상태 방 개수
+  private Long playingRoomCount; // 해당 장소의 RUNNING 상태 방 개수
+}

--- a/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/dto/response/RoomDetailResponse.java
+++ b/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/dto/response/RoomDetailResponse.java
@@ -8,10 +8,12 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class RoomDetailResponse {
     private Long roomId;
     private Long hostId;

--- a/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/entity/Room.java
+++ b/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/entity/Room.java
@@ -17,7 +17,9 @@ import java.util.Collections;
 import java.util.List;
 
 @Entity
-@Table(name = "rooms")
+@Table(name = "rooms", indexes = {
+    @Index(name = "idx_room_location_status", columnList = "location_id, status")
+})
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -81,15 +83,15 @@ public class Room {
     // 정적 팩토리 메서드
     @Builder(builderMethodName = "createBuilder")
     public static Room create(
-            Long hostId,
-            Long locationId,
-            String title,
-            Integer maxPlayers,
-            Integer policeCount,
-            Integer thiefCount,
-            LocalDateTime startTime,
-            Integer playTime,
-            RoleAssignMode roleAssignMode
+        Long hostId,
+        Long locationId,
+        String title,
+        Integer maxPlayers,
+        Integer policeCount,
+        Integer thiefCount,
+        LocalDateTime startTime,
+        Integer playTime,
+        RoleAssignMode roleAssignMode
     ) {
         validateCreateParams(startTime, maxPlayers, policeCount, thiefCount);
 
@@ -102,7 +104,6 @@ public class Room {
         room.thiefCount = thiefCount;
         room.startTime = startTime;
         room.playTime = playTime;
-
 
         // 기본값 설정
         room.roleAssignMode = (roleAssignMode == null) ? RoleAssignMode.RANDOM : roleAssignMode;
@@ -205,6 +206,13 @@ public class Room {
             throw new BusinessException(RoomErrorCode.INVALID_ROOM_STATUS);
         }
         this.status = RoomStatus.FINISHED;
+    }
+
+    public void transitionToWatting() {
+        if (this.status != RoomStatus.FINISHED) {
+            throw new BusinessException(RoomErrorCode.INVALID_ROOM_STATUS);
+        }
+        this.status = RoomStatus.WAITING;
     }
 
 

--- a/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/service/RoomService.java
+++ b/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/service/RoomService.java
@@ -3,9 +3,11 @@ package com.notFoundTomAndJerry.notFoundJerry.domain.room.service;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.request.CreateRoomRequest;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.request.RoomListRequest;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.JoinRoomResponse;
+import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.LocationWithRoomCountResponse;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.RoomDetailResponse;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.RoomListResponse;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.entity.enums.ParticipantRole;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -40,4 +42,10 @@ public interface RoomService {
      * 역할 변경 (MANUAL 모드 전용)
      */
     void changeRole(Long roomId, Long userId, ParticipantRole newRole);
+
+    /**
+     * 지도 마커용 데이터 조회 (영역 내 장소별 방 개수)
+     */
+    List<LocationWithRoomCountResponse> getMapMarkers(Double minLat, Double maxLat, Double minLng,
+        Double maxLng);
 }

--- a/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/service/RoomServiceImpl.java
+++ b/src/main/java/com/notFoundTomAndJerry/notFoundJerry/domain/room/service/RoomServiceImpl.java
@@ -5,6 +5,7 @@ import com.notFoundTomAndJerry.notFoundJerry.domain.room.converter.RoomConverter
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.request.CreateRoomRequest;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.request.RoomListRequest;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.JoinRoomResponse;
+import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.LocationWithRoomCountResponse;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.RoomDetailResponse;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.dto.response.RoomListResponse;
 import com.notFoundTomAndJerry.notFoundJerry.domain.room.entity.Room;
@@ -15,6 +16,7 @@ import com.notFoundTomAndJerry.notFoundJerry.domain.room.repository.RoomReposito
 import com.notFoundTomAndJerry.notFoundJerry.domain.user.repository.UserRepository;
 import com.notFoundTomAndJerry.notFoundJerry.global.exception.BusinessException;
 import com.notFoundTomAndJerry.notFoundJerry.global.exception.domain.RoomErrorCode;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -112,6 +114,15 @@ public class RoomServiceImpl implements RoomService {
     public void changeRole(Long roomId, Long userId, ParticipantRole newRole) {
         Room room = findRoomById(roomId);
         room.changeParticipantRole(userId, newRole);
+    }
+
+    // 지도 마커 조회 로직
+    @Override
+    @Transactional(readOnly = true)
+    public List<LocationWithRoomCountResponse> getMapMarkers(Double minLat, Double maxLat,
+        Double minLng, Double maxLng) {
+        // Repository에 작성한 SUM(CASE WHEN...) 쿼리를 호출
+        return roomRepository.findAllWithRoomStatusCount(minLat, maxLat, minLng, maxLng);
     }
 
     // =================================================================


### PR DESCRIPTION


## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호

#73 
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- LocationWithRoomCountResponse DTO 작성
- RoomService에 지도 마커 조회 서비스 메서드 추가
- RoomRepository에 특정 영역 내 방 상태별 집계 쿼리 작성
- LocationController와 RoomController에 API 구현
- Location 엔티티에 위도, 경도 필드 추가 및 공공 데이터 업데이트 로직 수정
- Room 엔티티에 상태별 조회 최적화 위한 인덱스 추가
### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
